### PR TITLE
Use Crave to schedule builds on 8 core machines

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -25,11 +25,16 @@ jobs:
       with:
         java-version: 1.11
         distribution: 'zulu'
+    - name: Get the Crave binary
+      run: curl -s https://raw.githubusercontent.com/accupara/crave/master/get_crave.sh | bash -s --
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
       working-directory: ${{env.working-directory}}
     - name: Build with Gradle
-      run: ./gradlew jacocoTestReport
+      run: crave run --clean -- ./gradlew jacocoTestReport
+      working-directory: ${{env.working-directory}}
+    - name: Get back the codecov report
+      run: crave pull build/reports/jacoco/test/jacocoTestReport.xml
       working-directory: ${{env.working-directory}}
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v1

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -19,7 +19,7 @@ jobs:
       working-directory: ./code/ingest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up JDK 1.11
       uses: actions/setup-java@v1
       with:

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -25,6 +25,8 @@ jobs:
       with:
         java-version: 1.11
         distribution: 'zulu'
+    - name: Unshallow the repo
+      run: /usr/bin/git fetch --unshallow
     - name: Get the Crave binary
       run: curl -s https://raw.githubusercontent.com/accupara/crave/master/get_crave.sh | bash -s --
       working-directory: ${{env.working-directory}}

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -27,14 +27,15 @@ jobs:
         distribution: 'zulu'
     - name: Get the Crave binary
       run: curl -s https://raw.githubusercontent.com/accupara/crave/master/get_crave.sh | bash -s --
+      working-directory: ${{env.working-directory}}
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
       working-directory: ${{env.working-directory}}
     - name: Build with Gradle
-      run: crave run --clean -- ./gradlew jacocoTestReport
+      run: ./crave run --clean -- ./gradlew jacocoTestReport
       working-directory: ${{env.working-directory}}
     - name: Get back the codecov report
-      run: crave pull build/reports/jacoco/test/jacocoTestReport.xml
+      run: ./crave pull build/reports/jacoco/test/jacocoTestReport.xml
       working-directory: ${{env.working-directory}}
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v1


### PR DESCRIPTION
- Download the crave binary
- Build and test with crave
- Download the codecov report file for the next codecov step